### PR TITLE
Allow for any action type when creating an action

### DIFF
--- a/lib/hypertrack/resources/action.rb
+++ b/lib/hypertrack/resources/action.rb
@@ -7,7 +7,6 @@ module HyperTrack
 
     VALID_ATTRIBUTE_VALUES = {
       type: {
-        allowed: [:pickup, :delivery, :dropoff, :visit, :stoppver, :task],
         allow_nil: true
       },
       vehicle_type: {


### PR DESCRIPTION
Following the specs of the v2 API, we can now name an action however we like, so no more need to constraint the type of the action with the given enum.